### PR TITLE
add charges controller

### DIFF
--- a/app/assets/javascripts/charges.coffee
+++ b/app/assets/javascripts/charges.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/charges.scss
+++ b/app/assets/stylesheets/charges.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the charges controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,9 @@ class ApplicationController < ActionController::Base
     '/customers/dashboard'
   end
 
+  def guest_or_customer_id
+    customer_signed_in? ? current_customer.id : session['session_id']
+  end
 
   def layout_by_resource
     if devise_controller? && !(current_employee || current_customer)

--- a/app/controllers/carted_products_controller.rb
+++ b/app/controllers/carted_products_controller.rb
@@ -1,10 +1,9 @@
 class CartedProductsController < ApplicationController
-  def create
-    customer_id = customer_signed_in? ? current_customer.id : session['session_id'] 
+  def create 
     @carted_product = CartedProduct.new(quantity: params[:quantity],
                                         product_id: params[:product_id],
                                         sku: params[:sku],
-                                        user_id: customer_id,
+                                        user_id: guest_or_customer_id,
                                         status: 'carted')
     if @carted_product.save
       flash[:success] = 'Order Created!'
@@ -15,14 +14,12 @@ class CartedProductsController < ApplicationController
     end
   end 
 
-  def index
-    customer_id = customer_signed_in? ? current_customer.id : session['session_id'] 
-    @carted_products = CartedProduct.where(status: 'carted', user_id: customer_id)
+  def index 
+    @carted_products = CartedProduct.my_carted(guest_or_customer_id)
     if @carted_products.empty?
-      flash[:warning] = 'You have nothing in your cart.'
+      flash[:warning] = 'Your cart is currently empty.'
       redirect_to '/'
     end
-    @carted_products.each{ |c| c.stripe_attributes }
   end 
 
   def destroy 

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -1,0 +1,29 @@
+class ChargesController < ApplicationController
+  def create
+    carted_products = CartedProduct.my_carted(guest_or_customer_id)
+    @amount = carted_products.sum(&:total_price)
+
+    if customer_signed_in?
+      customer = Stripe::Customer.retrieve(current_customer.stripe_customer_id)
+    else
+      customer = Stripe::Customer.create(
+        :email  => params[:stripeEmail],
+        :source => params[:stripeToken]
+      )
+    end
+
+    charge = Stripe::Charge.create(
+      :customer    => customer.id,
+      :amount      => @amount,
+      :description => 'Rails Stripe customer',
+      :currency    => 'usd'
+    )
+
+    rescue Stripe::CardError => e
+      flash[:error] = e.message
+      redirect_to '/cart'
+    else
+      flash[:success] = "Charge created!"
+      redirect_to '/' #order/:id ?
+  end
+end

--- a/app/helpers/charges_helper.rb
+++ b/app/helpers/charges_helper.rb
@@ -1,0 +1,2 @@
+module ChargesHelper
+end

--- a/app/views/carted_products/index.html.erb
+++ b/app/views/carted_products/index.html.erb
@@ -22,5 +22,26 @@
     </tr>
   <% end %>
 </table>
-
-<h3> Total Sale: <%= number_to_currency(@carted_products.sum(&:total_price) * 0.01) %> </h3>
+<div class="row">
+  <div class="col s6"></div>
+  <div class="col s6 right-align">
+    <h4> Total Sale: <%= number_to_currency(@carted_products.sum(&:total_price) * 0.01) %> </h4>
+    <%= form_tag charges_path do %>
+      <article>
+        <% if flash[:error].present? %>
+          <div id="error_explanation">
+            <p><%= flash[:error] %></p>
+          </div>
+        <% end %>
+      </article>
+      <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+              data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
+              data-description="Back of the Yards Coffee"
+              data-email="<%= current_customer.email if customer_signed_in? %>"
+              data-amount="<%= @carted_products.sum(&:total_price) %>"
+              data-locale="auto"
+              data-label="Buy Now"
+              data-shipping-address="true"></script>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/charges.html.erb
+++ b/app/views/layouts/charges.html.erb
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   get "/cart" => "carted_products#index"
   
   resources :products
+  resources :charges
 end

--- a/spec/controllers/charges_controller_spec.rb
+++ b/spec/controllers/charges_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ChargesController, type: :controller do
+
+end

--- a/spec/helpers/charges_helper_spec.rb
+++ b/spec/helpers/charges_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ChargesHelper. For example:
+#
+# describe ChargesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ChargesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,15 +34,21 @@ RSpec.configure do |config|
     # Stub for Stripe::Product.list
     stub_request(:get, "https://api.stripe.com/v1/products").
       to_return(:body => %Q({ "data": [
-        {"id":"prod_AuxRSpec01234","object":"product","attributes":"featured"},
-        {"id":"prod_AuxRSpec56789","object":"product","attributes":"special"}]
+        {"id":"prod_AuxRSpec01234","object":"product","attributes":"featured",
+          "skus":{"data":[{"id":"whole_bean","object":"product","attributes":"featured", "price":999}]}
+        },
+        {"id":"prod_AuxRSpec56789","object":"product","attributes":"special",
+          "skus":{"data":[{"id":"whole_bean","object":"product","attributes":"featured", "price":999}]}
+        }]
       }))
     # Stub for Stripe::Product.retrieve(id: product_id)
     stub_request(:get, "https://api.stripe.com/v1/products/prod_AuxRSpec01234").
-      to_return(:body => %Q({"id":"prod_AuxRSpec01234","object":"product","attributes":"featured", "name":"PRODUCT NAME"}))
-      # Stub for Stripe::Product.retrieve(id: product_id)
+      to_return(:body => %Q({"id":"prod_AuxRSpec01234","object":"product","attributes":"featured", "name":"PRODUCT NAME",
+        "skus":{"data":[{"id":"whole_bean","object":"product","attributes":"featured", "price":999}]}
+      }))
+      # Stub for Stripe::SKU.retrieve(id: sku)
     stub_request(:get, "https://api.stripe.com/v1/skus/whole_bean").
-      to_return(:body => %Q({"id":"prod_AuxRSpec01234","object":"product","attributes":"featured", "price":999}))
+      to_return(:body => %Q({"id":"whole_bean","object":"product","attributes":"featured", "price":999}))
     # Stub for Stripe::Plan.list
     stub_request(:get, "https://api.stripe.com/v1/plans").
       to_return(:body => %Q({ "data": [{"id":"test","object":"plan"}]}))


### PR DESCRIPTION
[Link to Trello Card](https://trello.com/c/bPS3yoKa/65-as-a-customer-i-will-be-able-to-click-buy-now-button-on-the-shopping-page-and-complete-a-transaction)

I wanted to get this added so we can move forward and get comfortable making transactions with the Stripe API.  This is just using the [simple checkout](https://stripe.com/docs/checkout/rails) integration. We may need to add more custom features but for now this is great.