### PR TITLE
Basic Stripe cache

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,8 @@
 class PagesController < ApplicationController
   def index
-    @products = Stripe::Product.list.select { |product| product.attributes.include?('featured') }
-    @subscriptions = Stripe::Plan.list(limit: 50)
+    # @products = Stripe::Product.list.select { |product| product.attributes.include?('featured') }
+    @products = StripeCache.new.featured_products
+    # @subscriptions = Stripe::Plan.list(limit: 50)
   end
 
   def about; end

--- a/app/services/stripe_cache.rb
+++ b/app/services/stripe_cache.rb
@@ -1,0 +1,15 @@
+class StripeCache
+  def initialize
+
+  end
+
+  def products
+    Rails.cache.fetch('stripe/products', expires_in: 5.minutes) do
+      Stripe::Product.list
+    end
+  end
+
+  def featured_products
+    products.select { |p| p.attributes.include?('featured') }
+  end
+end


### PR DESCRIPTION
@jklockri 
The StripeCache service object can be used to temporarily cache stripe data to improve subsequent load times