### PR TITLE
Remove container pids

### DIFF
--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,2 +1,6 @@
 class Api::ProductsController < ApplicationController
+  def index
+    @products = Stripe::Product.list
+    render "index.json.jbuilder"
+  end
 end

--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,6 +1,2 @@
 class Api::ProductsController < ApplicationController
-  def index
-    @products = Stripe::Product.list
-    render "index.json.jbuilder"
-  end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - SENDGRID_PASSWORD
       - ROLLBAR_ACESS_KEY
     
-    command: bundle exec rails s -p 3000 -b '0.0.0.0' -e development
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0' -e development"
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
This fixes the issue of running the rails web server when trying to bring the web container up.

Example error message:
```
web_1  | A server is already running. Check /app/tmp/pids/server.pid.
```

This fix will delete the `/app/tmp/pids/server.pid` file each time you bring the container back up, assuring that you that port `3000` will be available inside the container.

If you still see the error message above, it might be that port `3000` is in use on your local machine. To kill the process on your local machine, run the following commands in your **Terminal**:
```
sudo lsof -i tcp:3000 
kill -9 <PID NUMBER>
```