### PR TITLE
Fix Fix crash when new products added to stripe

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,7 +7,7 @@ class PagesController < ApplicationController
 
   def coffee_club
     @products = Stripe::Product.list(active: true)
-      .select { |product| product.attributes.include?('featured') }
+                               .select { |product| product.attributes.include?('featured') }
     @subscriptions = Stripe::Plan.list(limit: 50)
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,14 +1,13 @@
 class PagesController < ApplicationController
   def index
-    # @products = Stripe::Product.list.select { |product| product.attributes.include?('featured') }
     @products = StripeCache.new.featured_products
-    # @subscriptions = Stripe::Plan.list(limit: 50)
   end
 
   def about; end
 
   def coffee_club
-    @products = Stripe::Product.list.select { |product| product.attributes.include?('featured') }
+    @products = Stripe::Product.list(active: true)
+      .select { |product| product.attributes.include?('featured') }
     @subscriptions = Stripe::Plan.list(limit: 50)
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
   def index
-    @products = Stripe::Product.list(limit: 50)
+    @products = StripeCache.new.products
   end
 
   def show

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,2 +1,6 @@
 module PagesHelper
+  def starting_price(product)
+    prices = product.skus.map { |p| p.price.to_f / 100 }
+    number_to_currency(prices.min)
+  end
 end

--- a/app/services/stripe_cache.rb
+++ b/app/services/stripe_cache.rb
@@ -1,11 +1,9 @@
 class StripeCache
-  def initialize
-
-  end
+  def initialize; end
 
   def products
     Rails.cache.fetch('stripe/products', expires_in: 5.minutes) do
-      Stripe::Product.list
+      Stripe::Product.list(active: true).select { |p| p.skus.data.length.positive? }
     end
   end
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -49,7 +49,7 @@
               <span class="card-title grey-text text-darken-4"><%=product.name%>
                 <i class="material-icons right">close</i></span>
               <p><%=product.description%></p>
-              <p>Starting at <%=number_to_currency(product.skus.data[1].price.to_f / 100)%></p>
+              <p>Starting at <%= starting_price(product) %></p>
               <a href="/products/<%= product.id %>" button class="btn waves-effect waves-light botyred " type="submit" name="action" text-align="center">Go to product</a>
             </div>
           </div>

--- a/app/views/products/_form_for_buying_products.html.erb
+++ b/app/views/products/_form_for_buying_products.html.erb
@@ -8,24 +8,25 @@
       </div>
     </div>
   </div>
-
-  <div id="sku_form" class="section" style="height:100px">
-    <div class="row">
-      <div class="input-field">
-        <%= select_tag :sku, options_for_select(@product.skus.data.collect{|x| [x.attributes.bean_style, x.id]}), prompt: " - Select Bean Style - " %>
-        <label>Bean Style</label>
+  <% if @product.attributes.include?('bean_style') %>
+    <div id="sku_form" class="section" style="height:100px">
+      <div class="row">
+        <div class="input-field">
+          <%= select_tag :sku, options_for_select(@product.skus.data.collect{|x| [x.attributes.bean_style, x.id]}), prompt: " - Select Bean Style - " %>
+          <label>Bean Style</label>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div id="subscription_form" class="section" style="height:100px;display:none">
-    <div class="row">
-      <div class="input-field">
-        <%= select_tag :grind, options_for_select(['Ground','Whole Bean']), prompt: " - Select Bean Style - " %>
-        <label>Bean Style</label>
+    <div id="subscription_form" class="section" style="height:100px;display:none">
+      <div class="row">
+        <div class="input-field">
+          <%= select_tag :grind, options_for_select(['Ground','Whole Bean']), prompt: " - Select Bean Style - " %>
+          <label>Bean Style</label>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 
   <div class="section" style="height:100px;">
     <div class="row">

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -21,8 +21,7 @@
         </span>
         <div class="innercard">
           <p><%=product.description%></p>
-          <p>Starting at
-            <%=number_to_currency(product.skus.data[1].price.to_f / 100)%></p>
+          <p>Starting at <%= starting_price(product) %></p>
             <div class="section">
           <div class="row">
             <div class="col s6">

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe PagesController, type: :controller do
-
   describe 'GET pages#index' do
-
     context 'as a guest' do
       it 'should render the front page/index page' do
+        allow(Stripe::Product).to receive(:list).and_return([])
         get :index
         expect(response).to render_template :index
       end
@@ -17,6 +16,7 @@ RSpec.describe PagesController, type: :controller do
         sign_in customer
       end
       it 'should render the front page/index page' do
+        allow(Stripe::Product).to receive(:list).and_return([])
         get :index
         expect(response).to render_template :index
       end
@@ -39,6 +39,7 @@ RSpec.describe PagesController, type: :controller do
 
   describe 'GET pages#coffee_club' do
     it 'should render the coffee_club page' do
+    allow(Stripe::Product).to receive(:list).and_return([])
       get :coffee_club
       expect(response).to render_template :coffee_club
     end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PagesController, type: :controller do
 
   describe 'GET pages#coffee_club' do
     it 'should render the coffee_club page' do
-    allow(Stripe::Product).to receive(:list).and_return([])
+      allow(Stripe::Product).to receive(:list).and_return([])
       get :coffee_club
       expect(response).to render_template :coffee_club
     end

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe ProductsController, type: :controller do
   describe "GET products#index" do
     it "should render the index page" do
+      allow(Stripe::Product).to receive(:list).and_return([])
       get :index
       expect(response).to render_template :index
     end


### PR DESCRIPTION
The front page and product pages were crashing when anyone changed the stripe product list in certain ways. The checkout process still does not work for products that aren't coffee, but at least now the page wont crash just because someone is editing stripe data.
Trello: [As an EMPLOYEE, I want to add a new product on Stripe](https://trello.com/c/MJjoL8Ij)

* Mocks were added to some specifications to get them to run without using the stripe api. 
* A helper that calculates the starting price for a product was abstracted out of view code. 
* Stripe calls were modified to only retrieve products that are currently 'active'. 
* A boolean statement prevents trying to render a dropdown to select 'bean_style' for something that is not coffee.

WIP: need to see if hound is happy
