### PR TITLE
Improvement Upon Orders

### DIFF
--- a/app/assets/javascripts/product_index.js
+++ b/app/assets/javascripts/product_index.js
@@ -24,12 +24,8 @@ $(document).ready(function() {
     $select.change(function(){
       if ($(this).val() === "One Time Buy") {
         formAction.attr('action', '/cart');
-        $('#sku_form').show();
-        $('#subscription_form').hide();
       } else {
         formAction.attr('action', '/carted_subscription');
-        $('#sku_form').hide();
-        $('#subscription_form').show();
       }
     })
   }

--- a/app/assets/javascripts/product_show.js
+++ b/app/assets/javascripts/product_show.js
@@ -30,13 +30,7 @@ $('.products.index').ready(function() {
       errors.push('No quantity selected');
     }
     // Check for sku or grind depending on plan_id
-    if (
-      (params['plan_id'] === 'One Time Buy' && params['sku'] === '') ||
-      (params['plan_id'] !== 'One Time Buy' &&
-        params['plan_id'] !== '' &&
-        params['grind'] === '') ||
-      (params['sku'] === '' && params['grind'] == '')
-    ) {
+    if (params['sku'] === '') {
       ready = false;
       errors.push('No bean style selected');
     }

--- a/app/controllers/carted_subscriptions_controller.rb
+++ b/app/controllers/carted_subscriptions_controller.rb
@@ -4,7 +4,7 @@ class CartedSubscriptionsController < ApplicationController
       status: 'carted',
       customer_id: guest_or_customer_id,
       plan_id: params[:plan_id],
-      grind: params[:grind]
+      sku: params[:sku]
     )
 
     if carted_subscription
@@ -31,11 +31,11 @@ class CartedSubscriptionsController < ApplicationController
         status: 'carted',
         plan_id: params[:plan_id],
         plan_name: plan.first.id,
-        grind: params[:grind],
         amount: plan[0].amount,
         interval: plan[0].interval,
         interval_count: plan[0].interval_count,
-        product_id: params[:product_id]
+        product_id: params[:product_id],
+        sku: params[:sku]
       )
     end
     if carted_subscription.save

--- a/app/models/carted_subscription.rb
+++ b/app/models/carted_subscription.rb
@@ -1,7 +1,6 @@
 class CartedSubscription < ApplicationRecord
   belongs_to :customer, optional: true
   validates :plan_id, presence: { message: 'Please select a plan' }
-  validates :grind, presence: { message: 'Please select a bean style' }
   validates :quantity, numericality: { greater_than: 0, message: 'Please select a quantity' }
   scope :my_carted, ->(id) { where(status: 'carted', customer_id: id) }
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -78,7 +78,13 @@ class Customer < ApplicationRecord
   end
 
   def carted_items
-    carted_products.where(status: 'carted').map { |o| { type: 'sku', parent: o.sku, quantity: o.quantity } }
+    products = carted_products.where(status: 'carted')
+    subscriptions = carted_subscriptions.where(status: 'carted')
+
+    stripe_products = carted_products.map { |o| { type: 'sku', parent: o.sku, quantity: o.quantity } } || []
+    stripe_subscriptions = carted_subscriptions.map { |o| { type: 'sku', parent: o.sku, quantity: o.quantity } } || []
+
+    stripe_products + stripe_subscriptions
   end
 
   def carted_products_and_subscription_quantity

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -38,7 +38,7 @@
             </thead>
             <tbody>
               <% if @stripe_order.present? %>
-                <% @stripe_order.items.select{|item| item.type == "sku"}.each do |item| %>
+                <% @sku_items.each do |item| %>
                   <% if item.amount > 0 %>
                     <tr>
                       <td><%= item.description %></td>
@@ -47,13 +47,6 @@
                     </tr>
                   <% end %>
                 <% end %>
-              <% end %>
-              <% @carted_subscriptions.each do |item| %>
-                <tr>
-                  <td><%= item.plan_name %></td>
-                  <td><%= item.quantity %></td>
-                  <td> <%= number_to_currency(item.amount * 0.01)%></td>
-                </tr>
               <% end %>
             </tbody>
         </table>
@@ -70,8 +63,8 @@
           </thead>
           <tbody>
             <tr>
-              <td>Items(<%= @total_quantity %>)</td>
-              <td><%= number_to_currency(@total) %></td>
+              <td>Items(<%= @sku_items.length %>)</td>
+              <td><%= number_to_currency(@stripe_order_total) %></td>
             </tr>
             <tr>
               <% if @stripe_order.present? %>

--- a/app/views/products/_form_for_buying_products.html.erb
+++ b/app/views/products/_form_for_buying_products.html.erb
@@ -1,5 +1,4 @@
 <%= form_tag "/cart", method: :post do%>
-
   <div class="section" style="height:100px;">
     <div class="row">
       <div class="input-field plan_select" id="plan_id">
@@ -13,15 +12,6 @@
       <div class="row">
         <div class="input-field">
           <%= select_tag :sku, options_for_select(@product.skus.data.collect{|x| [x.attributes.bean_style, x.id]}), prompt: " - Select Bean Style - " %>
-          <label>Bean Style</label>
-        </div>
-      </div>
-    </div>
-
-    <div id="subscription_form" class="section" style="height:100px;display:none">
-      <div class="row">
-        <div class="input-field">
-          <%= select_tag :grind, options_for_select(['Ground','Whole Bean']), prompt: " - Select Bean Style - " %>
           <label>Bean Style</label>
         </div>
       </div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,10 +22,10 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
-  <<: *default
   host: db
   username: postgres
   password:
+  <<: *default
   database: back-yards-coffee-app_development
 
   # The specified database role being used to connect to postgres.

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,10 +22,10 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
+  <<: *default
   host: db
   username: postgres
   password:
-  <<: *default
   database: back-yards-coffee-app_development
 
   # The specified database role being used to connect to postgres.

--- a/db/migrate/20180404234535_add_sku_to_carted_subscription.rb
+++ b/db/migrate/20180404234535_add_sku_to_carted_subscription.rb
@@ -1,0 +1,5 @@
+class AddSkuToCartedSubscription < ActiveRecord::Migration[5.0]
+  def change
+    add_column :carted_subscriptions, :sku, :string
+  end
+end

--- a/db/migrate/20180405010334_remove_grind_from_carted_subscriptions.rb
+++ b/db/migrate/20180405010334_remove_grind_from_carted_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveGrindFromCartedSubscriptions < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :carted_subscriptions, :grind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180326235105) do
+ActiveRecord::Schema.define(version: 20180405010334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 20180326235105) do
     t.string   "plan_id"
     t.string   "status"
     t.bigint   "customer_id"
-    t.string   "grind"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.integer  "amount"
@@ -42,6 +41,7 @@ ActiveRecord::Schema.define(version: 20180326235105) do
     t.integer  "interval_count"
     t.string   "plan_name"
     t.string   "product_id"
+    t.string   "sku"
   end
 
   create_table "categories", force: :cascade do |t|

--- a/spec/factories/carted_subscriptions.rb
+++ b/spec/factories/carted_subscriptions.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     plan_id 'Weekly / $42.00 per bag'
     status 'carted'
     customer_id 1
-    grind 'Ground'
     interval 'week'
     interval_count 1
     plan_name 'bob-weekly'
@@ -16,7 +15,6 @@ FactoryGirl.define do
     plan_id 'Weekly / $42.00 per bag'
     status 'subscribed'
     customer_id 1
-    grind 'Ground'
     interval 'week'
     interval_count 1
     plan_name 'bob-weekly'


### PR DESCRIPTION
- Allows the subscriptions to have Stripe::Orders created
  - adds SKU field to CartedSubscription to make this happen, gets rid of `grind` field. Since it is not needed or used
- Makes sure the correct values display on the checkout screen

- https://trello.com/c/aIX0lLOT/142-subscriptions-integrate-shipping-cost-and-taxes

- Fixes subscriptions

```
stripe_products = carted_products.map { |o| { type: 'sku', parent: o.sku, quantity: o.quantity } } || []
stripe_subscriptions = carted_subscriptions.map { |o| { type: 'sku', parent: o.sku, quantity: o.quantity } } || []
```
-Changed the way that products and subscriptions appear in the cart.

5. Any screenshots, metrics, or any other information that shows the changes you provided
![image](https://user-images.githubusercontent.com/16711232/38344025-e968f6de-384c-11e8-94dc-02fc1e615379.png)
