### PR TITLE
Carting of non-coffee products

### DIFF
--- a/app/assets/javascripts/product_index.js
+++ b/app/assets/javascripts/product_index.js
@@ -1,36 +1,23 @@
 $(document).ready(function() {
   $('select').material_select();
-  $('.tooltipped').tooltip({delay: 5});
+  $('.tooltipped').tooltip({ delay: 5 });
   const addToCart = document.querySelectorAll('.add');
 
   function buyForm() {
-    const thisProdId = this.id.slice(2)
+    const thisProdId = this.id.slice(2);
     $.ajax({
       type: 'GET',
       url: `/products/${thisProdId}`,
-      success: (data) => {
-        this.closest(".innercard").innerHTML = data
+      success: data => {
+        this.closest('.innercard').innerHTML = data;
       },
       error: function() {}
     }).then(function() {
-        $('select').material_select();
-        addUI();
-      });
-  }
-
-  function addUI(){
-    var $select = $('.plan_select').find('select');
-    const formAction = $('form');
-    $select.change(function(){
-      if ($(this).val() === "One Time Buy") {
-        formAction.attr('action', '/cart');
-      } else {
-        formAction.attr('action', '/carted_subscription');
-      }
-    })
+      $('select').material_select(); // Make sure materialize properly displays dropdowns
+    });
   }
 
   for (var i = 0; i < addToCart.length; i++) {
     addToCart[i].addEventListener('click', buyForm);
   }
-})
+});

--- a/app/assets/javascripts/product_index.js
+++ b/app/assets/javascripts/product_index.js
@@ -3,13 +3,16 @@ $(document).ready(function() {
   $('.tooltipped').tooltip({ delay: 5 });
   const addToCart = document.querySelectorAll('.add');
 
-  function buyForm() {
+  function buyForm(event) {
+    event.preventDefault();
     const thisProdId = this.id.slice(2);
     $.ajax({
       type: 'GET',
       url: `/products/${thisProdId}`,
       success: data => {
-        this.closest('.innercard').innerHTML = data;
+        $(this)
+          .closest('.innercard')
+          .html(data);
       },
       error: function() {}
     }).then(function() {
@@ -17,7 +20,5 @@ $(document).ready(function() {
     });
   }
 
-  for (var i = 0; i < addToCart.length; i++) {
-    addToCart[i].addEventListener('click', buyForm);
-  }
+  $('.add').on('click', buyForm);
 });

--- a/app/controllers/carted_products_controller.rb
+++ b/app/controllers/carted_products_controller.rb
@@ -12,14 +12,16 @@ class CartedProductsController < ApplicationController
         redirect_to '/cart'
       end
     else
+      @product = StripeCache.new.product(params[:product_id])
+      price = @product.skus.data.find { |sku| sku.id == params[:sku] } .price
       carted_product = CartedProduct.new(
         quantity: params[:quantity],
         product_id: params[:product_id],
         sku: params[:sku],
         customer_id: guest_or_customer_id,
         status: 'carted',
-        price: params[:price].to_i,
-        name: params[:name]
+        price: price,
+        name: @product.name
       ) ### supposed to catch and up the quantity if its the same ###
       if carted_product.save
         flash[:success] = 'Product Added to Cart!'

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,7 +1,6 @@
 class OrdersController < ApplicationController
   def new
-    params_order_id = params[:order_id]
-    @stripe_order = Stripe::Order.retrieve(params_order_id) if params_order_id.present?
+    p @stripe_order = Stripe::Order.retrieve(params[:order_id]) if params[:order_id].present?
 
     @stripe_order_quantity = @stripe_order&.items&.select{|item| item.type == "sku"}&.map{|item| item.quantity}&.sum || 0
     @total_quantity = @stripe_order_quantity
@@ -23,6 +22,7 @@ class OrdersController < ApplicationController
       customer.update(customer_params)
 
       if customer.carted_items.present?
+        puts "customer.carted_items: #{customer.carted_items}"
         @order = StripeTool.create_order(current_customer)
         order_id = @order[:order]['id']
       end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,6 @@
 class OrdersController < ApplicationController
   def new
-    p @stripe_order = Stripe::Order.retrieve(params[:order_id]) if params[:order_id].present?
+    @stripe_order = Stripe::Order.retrieve(params[:order_id]) if params[:order_id].present?
 
     @stripe_order_quantity = @stripe_order&.items&.select{|item| item.type == "sku"}&.map{|item| item.quantity}&.sum || 0
     @total_quantity = @stripe_order_quantity
@@ -17,19 +17,18 @@ class OrdersController < ApplicationController
   end
 
   def create
-    if customer_signed_in?
-      customer = current_customer
-      customer.update(customer_params)
+    redirect_to '/orders/new' unless customer_signed_in?
+    customer = current_customer
+    customer.update(customer_params)
 
-      if customer.carted_items.present?
-        puts "customer.carted_items: #{customer.carted_items}"
-        @order = StripeTool.create_order(current_customer)
-        order_id = @order[:order]['id']
-      end
-
-      # TODO: GUEST ORDER
-      redirect_to "/orders/new?order_id=#{order_id}"
+    if customer.carted_items.present?
+      # puts "customer.carted_items: #{customer.carted_items}"
+      @order = StripeTool.create_order(current_customer)
+      order_id = @order[:order]['id']
     end
+
+    # TODO: GUEST ORDER
+    redirect_to "/orders/new?order_id=#{order_id}"
     # TODO: REDIRECT TO 'ORDERS NEW
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,12 +5,12 @@ class ProductsController < ApplicationController
   end
 
   def show
-    p @product = Stripe::Product.retrieve(id: params[:id])
+    @product = Stripe::Product.retrieve(id: params[:id])
     if @product.metadata['plans']
       @plans = @product.metadata.plans.split(',')
       plan_names = { w: 'Weekly', b: 'Bi-Weekly', m: 'Monthly' }
       @plans.map! { |p| [plan_names[p.to_sym], p] }
-      @plans.unshift(["One Time Purchase", ""])
+      @plans.unshift(['One Time Purchase', ''])
     end
     @skus = @product.skus.data
     @skus.select! do |sku|
@@ -18,7 +18,7 @@ class ProductsController < ApplicationController
         (sku.inventory.type == 'infinite')
     end
     @skus.map! do |sku|
-      product_name = @product.name
+      # product_name = @product.name
       attributes = sku.attributes.map { |pr| pr[1] } .join(', ')
       cost = number_to_currency(sku.price.to_f / 100)
       ["#{attributes} #{cost}", sku.id]

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,16 +5,24 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Stripe::Product.retrieve(id: params[:id])
+    p @product = Stripe::Product.retrieve(id: params[:id])
+    if @product.metadata['plans']
+      @plans = @product.metadata.plans.split(',')
+      plan_names = { w: 'Weekly', b: 'Bi-Weekly', m: 'Monthly' }
+      @plans.map! { |p| [plan_names[p.to_sym], p] }
+      @plans.unshift(["One Time Purchase", ""])
+    end
     @skus = @product.skus.data
-                    .select { |sku| sku.inventory.quantity.positive? }
-                    .map do |sku|
-                      product_name = @product.name
-                      attributes = sku.attributes.map { |pr| pr.join('-') } .join(', ')
-                      cost = number_to_currency(sku.price.to_f / 100)
-
-                      ["#{product_name} #{attributes} #{cost}", sku.id]
-                    end
+    @skus.select! do |sku|
+      sku.inventory&.quantity&.positive? ||
+        (sku.inventory.type == 'infinite')
+    end
+    @skus.map! do |sku|
+      product_name = @product.name
+      attributes = sku.attributes.map { |pr| pr[1] } .join(', ')
+      cost = number_to_currency(sku.price.to_f / 100)
+      ["#{attributes} #{cost}", sku.id]
+    end
     render partial: 'form_for_buying_products', layout: false if request.xhr?
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,15 +1,20 @@
 class ProductsController < ApplicationController
+  include ActionView::Helpers::NumberHelper
   def index
     @products = StripeCache.new.products
   end
 
   def show
-    @subscriptions = Stripe::Plan.list(limit: 50).data
     @product = Stripe::Product.retrieve(id: params[:id])
+    @skus = @product.skus.data
+                    .select { |sku| sku.inventory.quantity.positive? }
+                    .map do |sku|
+                      product_name = @product.name
+                      attributes = sku.attributes.map { |pr| pr.join('-') } .join(', ')
+                      cost = number_to_currency(sku.price.to_f / 100)
 
-    @subscriptions = @subscriptions.select { |sub| sub['metadata'].to_h.present? && sub['metadata'].prod_id == @product.id }
-    @product_plan_options = StripeTool.product_plan_options(@subscriptions, @product.id)
-    @product_plan_options.push('One Time Buy')
+                      ["#{product_name} #{attributes} #{cost}", sku.id]
+                    end
     render partial: 'form_for_buying_products', layout: false if request.xhr?
   end
 

--- a/app/models/concerns/stripe_tool.rb
+++ b/app/models/concerns/stripe_tool.rb
@@ -22,7 +22,7 @@ module StripeTool
       sub['metadata'].to_h.present? && sub['metadata'].to_h[:prod_id] == prod_id
     end
 
-    prod_plans = plans.select{ |plan| (plan.metadata.prod_id == prod_id) }
+    prod_plans = plans.select { |plan| (plan.metadata.prod_id == prod_id) }
 
     interval = /\w+/.match(plan_id)[0].downcase.insert(0, '-')
     prod_plans.select { |plan| plan.id.include?(interval) }

--- a/app/models/concerns/stripe_tool.rb
+++ b/app/models/concerns/stripe_tool.rb
@@ -22,7 +22,7 @@ module StripeTool
       sub['metadata'].to_h.present? && sub['metadata'].to_h[:prod_id] == prod_id
     end
 
-    prod_plans = plans.select{|plan| (plan.metadata.prod_id == prod_id)}
+    prod_plans = plans.select{ |plan| (plan.metadata.prod_id == prod_id) }
 
     interval = /\w+/.match(plan_id)[0].downcase.insert(0, '-')
     prod_plans.select { |plan| plan.id.include?(interval) }

--- a/app/services/stripe_cache.rb
+++ b/app/services/stripe_cache.rb
@@ -7,6 +7,12 @@ class StripeCache
     end
   end
 
+  def product(prod_id)
+    Rails.cache.fetch("stripe/products#{prod_id}", expires_in: 5.minutes) do
+      Stripe::Product.retrieve(prod_id)
+    end
+  end
+
   def featured_products
     products.select { |product| product.metadata['featured'] }
   end

--- a/app/services/stripe_cache.rb
+++ b/app/services/stripe_cache.rb
@@ -8,6 +8,6 @@ class StripeCache
   end
 
   def featured_products
-    products.select { |p| p.attributes.include?('featured') }
+    products.select { |product| product.metadata['featured'] }
   end
 end

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -15,11 +15,15 @@
         <h5 class="LobsterCenter">2. Choose your delivery option:</h5>
         <% if @stripe_order.present? %>
         <form action="" >
+          <% p @stripe_order.shipping_methods %>
           <% @stripe_order.shipping_methods.each do |option| %>
             <input type="checkbox" name="<%= option.description %>"value="<%= option.id %>">
             <label>
-               <%= option.delivery_estimate[:date] %> <%= number_to_currency(option.amount * 0.01) %> - <%= option.description %>
-              </label>
+              <% if option.delivery_estimate %>
+                <%= option.delivery_estimate[:date] %>
+              <% end %>
+              <%= number_to_currency(option.amount * 0.01) %> - <%= option.description %>
+            </label>
           <% end %>
           <input class="btn" type="submit" value="Choose this shipping method">
         </form>

--- a/app/views/products/_form_for_buying_products.html.erb
+++ b/app/views/products/_form_for_buying_products.html.erb
@@ -1,17 +1,32 @@
 <%= form_tag "/cart", method: :post do%>
-  <div class="section" style="height:100px;">
-    <div class="row">
-      <div class="input-field plan_select" id="plan_id">
-        <%= select_tag :sku ,options_for_select(@skus), prompt: " - Select SKU - "%>
-        <label>Plan</label>
+  <% if @plans %>
+    <div class="section" style="height:100px;">
+      <div class="row">
+        <div class="input-field plan_select" id="plan_id">
+          <%= select_tag :plan ,options_for_select(@plans)%>
+          <label>Plan</label>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
+
+  <% if @product.attributes.length == 0 %>
+    <%= hidden_field_tag :sku, @skus.first[1] %>
+  <% else %>
+    <div class="section" style="height:100px;">
+      <div class="row">
+        <div class="input-field plan_select" id="plan_id">
+          <%= select_tag :sku ,options_for_select(@skus)%>
+          <label><%= @product.attributes.first.titleize %></label>
+        </div>
+      </div>
+    </div>
+  <% end %>
 
   <div class="section" style="height:100px;">
     <div class="row">
       <div class="input-field">
-        <%= select_tag :quantity, options_for_select((1..10).to_a), prompt: " - Select Quantity - " %>
+        <%= select_tag :quantity, options_for_select((1..10).to_a) %>
         <label>Quantity</label>
       </div>
     </div>

--- a/app/views/products/_form_for_buying_products.html.erb
+++ b/app/views/products/_form_for_buying_products.html.erb
@@ -2,32 +2,21 @@
   <div class="section" style="height:100px;">
     <div class="row">
       <div class="input-field plan_select" id="plan_id">
-        <%= select_tag :plan_id,options_for_select(@product_plan_options), prompt: " - Select Plan - "%>
+        <%= select_tag :sku ,options_for_select(@skus), prompt: " - Select SKU - "%>
         <label>Plan</label>
       </div>
     </div>
   </div>
-  <% if @product.attributes.include?('bean_style') %>
-    <div id="sku_form" class="section" style="height:100px">
-      <div class="row">
-        <div class="input-field">
-          <%= select_tag :sku, options_for_select(@product.skus.data.collect{|x| [x.attributes.bean_style, x.id]}), prompt: " - Select Bean Style - " %>
-          <label>Bean Style</label>
-        </div>
-      </div>
-    </div>
-  <% end %>
 
   <div class="section" style="height:100px;">
     <div class="row">
       <div class="input-field">
-        <%= select_tag :quantity, options_for_select((1..StripeTool.product_quantity(@product)).to_a), prompt: " - Select Quantity - " %>
+        <%= select_tag :quantity, options_for_select((1..10).to_a), prompt: " - Select Quantity - " %>
         <label>Quantity</label>
       </div>
     </div>
   </div>
   <%= hidden_field_tag :product_id, @product.id %>
-  <%= hidden_field_tag :price, @product.skus.data.first.price %>
   <%= hidden_field_tag :name, @product.name %>
   <button class="btn waves-effect waves-light" type="submit" name="submit">Add to Cart</button>
   <br>

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -1,23 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe ProductsController, type: :controller do
-  describe "GET products#index" do
-    it "should render the index page" do
+  describe 'GET products#index' do
+    it 'should render the index page' do
       allow(Stripe::Product).to receive(:list).and_return([])
       get :index
       expect(response).to render_template :index
     end
   end
-  describe "GET products#show" do
-    it "should render the show page" do
-      product_id = "prod_AuxRSpec01234"
-      get :show, id: product_id
+  describe 'GET products#show' do
+    it 'should render the show page' do
+      product = double('product')
+      skus = double('skus')
+      allow(Stripe::Product).to receive(:retrieve).and_return(product)
+      allow(product).to receive(:metadata).and_return({})
+      allow(product).to receive(:name).and_return('Foo')
+      allow(product).to receive(:skus).and_return(skus)
+      allow(skus).to receive(:data).and_return([])
+      get :show, id: 'foo'
       expect(response).to render_template :show
-      expect(assigns(:product).name).to eq("PRODUCT NAME")
+      expect(assigns(:product).name).to eq('Foo')
     end
   end
-  describe "GET products#subscriptions" do
-    it "should render the subscription page" do
+  describe 'GET products#subscriptions' do
+    it 'should render the subscription page' do
       get :subscriptions
       expect(response). to render_template :subscriptions
     end


### PR DESCRIPTION
[As an employee, I would like to add items to my cart that are not coffee](https://trello.com/c/nQKgSEQr)

Instead of a listing of bean_style, the form temporarily shows a dropdown where you select an sku (ux to improve later). This is because the controllers and ui were centered around the idea of only coffee and types of coffee. This is a transitional stage to having a UI that presents options dynamically depending on the type of product. Right now it looks like this:

<img width="413" alt="screen shot 2018-04-06 at 11 59 18 am" src="https://user-images.githubusercontent.com/4739591/38433854-03159376-3992-11e8-8d55-a4ee7188752c.png">
<img width="434" alt="screen shot 2018-04-06 at 11 59 08 am" src="https://user-images.githubusercontent.com/4739591/38433856-04eaf916-3992-11e8-9d88-7166936ef281.png">

