### PR TITLE
Setup redis and sidekiq images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'shippo', git: 'https://github.com/goshippo/shippo-ruby-client'
 gem 'awesome_print'
 gem 'lodash-rails'
 gem 'gon'
+gem 'sidekiq'
+gem 'redis', '~> 3.3', '>= 3.3.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: '3'
 services:
   db:
     image: postgres
+  redis:
+    image: 'redis:4.0-alpine'
+    volumes:
+      - 'redis:/data'
   web:
     build: .
     environment:
@@ -18,3 +22,14 @@ services:
       - "3000:3000"
     depends_on:
       - db
+  sidekiq:
+    depends_on:
+      - 'db'
+      - 'redis'
+    build: .
+    command: sidekiq -C config/sidekiq.yml.erb
+    volumes:
+      - '.:/app'
+volumes:
+  redis:
+  db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - redis
   sidekiq:
     depends_on:
       - 'db'


### PR DESCRIPTION
Setup redis and sidekiq in docker compose in order to begin developing background jobs.

**Trello**
[#225](https://trello.com/c/jKLi8ahy/225-subscription-setup-install-redis)
[#226](https://trello.com/c/DucauaIb/226-subscription-setup-install-sidekiq)
