### PR TITLE
Add new destroy method to CartedSubscriptions

### DIFF
--- a/app/controllers/carted_subscriptions_controller.rb
+++ b/app/controllers/carted_subscriptions_controller.rb
@@ -9,7 +9,7 @@ class CartedSubscriptionsController < ApplicationController
   end
 
   def update
-    @subscription = current_customer.carted_subscriptions.last
+    @subscription = CartedSubscription.find(params[:id])
     @subscription.assign_attributes(carted_subscription_update_params)
     unless @subscription.save
       flash[:error] = 'Error updating subscriptions' unless subscription.save
@@ -18,7 +18,12 @@ class CartedSubscriptionsController < ApplicationController
   end
 
   # for setting to inactive
-  def destroy; end
+  def destroy
+    @subscription = CartedSubscription.find(params[:id])
+    @subscription.status = 'inactive'
+    @subscription.expired_at = DateTime.now
+    @subscription.save
+  end
 
   private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
   get '/cart' => 'carted_products#index'
   patch '/cart' => 'carted_products#update'
 
-  resources :carted_subscriptions, only: [:index, :create, :update]
+  resources :carted_subscriptions, only: [:index, :create, :update, :destroy]
 
   get '/orders/new/' => 'orders#new'
   get '/orders/new:order_id' => 'orders#create'

--- a/spec/controllers/carted_subscriptions_controller_spec.rb
+++ b/spec/controllers/carted_subscriptions_controller_spec.rb
@@ -39,4 +39,19 @@ RSpec.describe CartedSubscriptionsController, type: :controller do
       end
     end
   end
+  describe '#destroy' do
+    before :each do
+      @customer = create(:customer)
+      sign_in @customer
+      @carted_subscription = create(:carted_subscription, customer: @customer)
+    end
+    it 'sets the subscription status to inactive and saves the time' do
+      post :destroy, params: {
+        id: @carted_subscription.id
+      }
+      @carted_subscription.reload
+      expect(@carted_subscription.status).to eq 'inactive'
+      expect(@carted_subscription.expired_at).to be_a Time
+    end
+  end
 end

--- a/spec/factories/carted_subscriptions.rb
+++ b/spec/factories/carted_subscriptions.rb
@@ -29,6 +29,7 @@ FactoryGirl.define do
       }
     end
     order_created_at Date.today
+    status 'active'
   end
 
   factory :subscribed_subscription, class: CartedSubscription do


### PR DESCRIPTION
Card #231 [Subscription Controller: Destroy action will change subscription status to inactive](https://trello.com/c/pI0DW9LC)
* Method sets the subscriptions status to 'inactive'
* Method persists the current time to the subscription at 'expired_at'
