### PR TITLE
Gemfile.lock including sidekiq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redis (3.3.5)
     request_store (1.4.0)
       rack (>= 1.4)
     responders (2.4.0)
@@ -244,6 +245,11 @@ GEM
     sendgrid-ruby (5.1.0)
       ruby_http_client (~> 3.2)
       sinatra (>= 1.4.7, < 3)
+    sidekiq (5.1.3)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -320,11 +326,13 @@ DEPENDENCIES
   rails (~> 5.0.3)
   rails-controller-testing
   react-rails
+  redis (~> 3.3, >= 3.3.1)
   rollbar
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0)
   sendgrid-ruby
   shippo!
+  sidekiq
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -335,5 +343,8 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webmock
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
Codeship deploys are failing due to issues with Gemfile.lock, attempting fix.