### PR TITLE
fix problem retrieving carted items for customer

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -78,13 +78,14 @@ class Customer < ApplicationRecord
   end
 
   def carted_items
-    products = carted_products.where(status: 'carted')
-    subscriptions = carted_subscriptions.where(status: 'carted')
-
-    stripe_products = carted_products.map { |o| { type: 'sku', parent: o.sku, quantity: o.quantity } } || []
-    stripe_subscriptions = carted_subscriptions.map { |o| { type: 'sku', parent: o.sku, quantity: o.quantity } } || []
-
-    stripe_products + stripe_subscriptions
+    carted_products.where(status: 'carted')
+                   .map do |o|
+                     {
+                       type: 'sku',
+                       parent: o.sku,
+                       quantity: o.quantity
+                     }
+                   end
   end
 
   def carted_products_and_subscription_quantity


### PR DESCRIPTION
# Card #240 [Fix orders](https://trello.com/c/O8eIMKUH)

There was an error during checkout because the customer object was returning duplicate carted products from the database.

* Change the `carted_items` customer method to return the correct set of items

This method will be returned to while adding subscriptions back to the checkout process.
