### PR TITLE
Change sidekiq config only in development

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,9 @@
-Sidekiq.configure_server do |config|
-  config.redis = { url: 'redis://redis:6379' }
-end
+if Rails.env.development?
+  Sidekiq.configure_server do |config|
+    config.redis = { url: "redis://redis:6379" }
+  end
 
-Sidekiq.configure_client do |config|
-  config.redis = { url: 'redis://redis:6379' }
+  Sidekiq.configure_client do |config|
+    config.redis = { url: "redis://redis:6379" }
+  end
 end


### PR DESCRIPTION
The sidekiq initializer only runs in development, because the normal settings should already work on test and qa